### PR TITLE
Add dynarmic support to liblfi

### DIFF
--- a/example/Knitfile
+++ b/example/Knitfile
@@ -1,11 +1,13 @@
 local cc = "gcc"
 local lficc = "/opt/lfi/toolchain/bin/lfi-clang"
 
+local libs = "-ldynarmic -lfmt -lmcl -lstdc++"
+
 return b{
     $ all:VB: run.elf hello.elf
 
     $ run.elf: run.c ../liblfi/liblfi.a ../lfi-verify/target/release/liblfiverify.a
-        $cc -O2 -I../liblfi $input -o $output -static
+        $cc -O2 -I../liblfi $input -o $output $libs -static
     $ hello.elf: hello.c
         $lficc -O2 $input -o $output -nostdlib
 }

--- a/liblfi/Knitfile
+++ b/liblfi/Knitfile
@@ -1,13 +1,16 @@
 local knit = require('knit')
 
 local cc = "gcc"
+local cxx = "g++"
 local cflags = "-O2 -Wall -Wextra"
 
 local csrc = knit.rglob(".", "*.c")
+local cppsrc = knit.rglob(".", "*.cpp")
 local ssrc = knit.rglob(".", "*.S")
 
 local obj = knit.join(
     knit.extrepl(csrc, ".c", ".o"),
+    knit.extrepl(cppsrc, ".cpp", ".o"),
     knit.extrepl(ssrc, ".S", ".o")
 )
 obj = knit.prefix(obj, ".")
@@ -16,9 +19,11 @@ return b{
     $ liblfi.a: $obj
         ar rcs $output $input
     $ .%.o:D[.%.dep]: %.c
-        $cc $cflags -MD -MF $dep -c $input -o $output
+        $cc $cflags -MD -MF $dep -c $input -o $output -DDYNARMIC_ENABLED
     $ .%.o: %.S
         $cc -c $input -o $output
+    $ .%.o:D[.%.dep]: %.cpp
+        $cxx $cflags -MD -MF $dep -c $input -o $output -std=c++20
 
     $ install:VB: liblfi.a
         install $input /usr/local/lib

--- a/liblfi/dynarmic.cpp
+++ b/liblfi/dynarmic.cpp
@@ -1,0 +1,187 @@
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <mcl/assert.hpp>
+#include "dynarmic.h"
+#include "dynarmic/interface/A64/a64.h"
+#include "dynarmic/interface/A64/config.h"
+
+using u8 = std::uint8_t;
+using u16 = std::uint16_t;
+using u32 = std::uint32_t;
+using u64 = std::uint64_t;
+using Vector = Dynarmic::A64::Vector;
+
+class A64FastmemTestEnv final : public Dynarmic::A64::UserCallbacks {
+public:
+    u64 ticks_left = 0;
+    char* backing_memory = nullptr;
+    Dynarmic::A64::Jit* jit;
+
+    explicit A64FastmemTestEnv(char* addr) : backing_memory(addr) {}
+
+    template<typename T>
+    T read(u64 vaddr) {
+        T value;
+        memcpy(&value, backing_memory + vaddr, sizeof(T));
+        return value;
+    }
+    template<typename T>
+    void write(u64 vaddr, const T& value) {
+        memcpy(backing_memory + vaddr, &value, sizeof(T));
+    }
+
+    std::optional<std::uint32_t> MemoryReadCode(u64 vaddr) override {
+        uint32_t result = read<std::uint32_t>(vaddr);
+            return result;
+    }
+
+    std::uint8_t MemoryRead8(u64 vaddr) override {
+        return read<std::uint8_t>(vaddr);
+    }
+    std::uint16_t MemoryRead16(u64 vaddr) override {
+        return read<std::uint16_t>(vaddr);
+    }
+    std::uint32_t MemoryRead32(u64 vaddr) override {
+        return read<std::uint32_t>(vaddr);
+    }
+    std::uint64_t MemoryRead64(u64 vaddr) override {
+        return read<std::uint64_t>(vaddr);
+    }
+    Vector MemoryRead128(u64 vaddr) override {
+        return read<Vector>(vaddr);
+    }
+
+    void MemoryWrite8(u64 vaddr, std::uint8_t value) override {
+        write(vaddr, value);
+    }
+    void MemoryWrite16(u64 vaddr, std::uint16_t value) override {
+        write(vaddr, value);
+    }
+    void MemoryWrite32(u64 vaddr, std::uint32_t value) override {
+        write(vaddr, value);
+    }
+    void MemoryWrite64(u64 vaddr, std::uint64_t value) override {
+        write(vaddr, value);
+    }
+    void MemoryWrite128(u64 vaddr, Vector value) override {
+        write(vaddr, value);
+    }
+
+    bool MemoryWriteExclusive8(u64 vaddr, std::uint8_t value, [[maybe_unused]] std::uint8_t expected) override {
+        MemoryWrite8(vaddr, value);
+        return true;
+    }
+    bool MemoryWriteExclusive16(u64 vaddr, std::uint16_t value, [[maybe_unused]] std::uint16_t expected) override {
+        MemoryWrite16(vaddr, value);
+        return true;
+    }
+    bool MemoryWriteExclusive32(u64 vaddr, std::uint32_t value, [[maybe_unused]] std::uint32_t expected) override {
+        MemoryWrite32(vaddr, value);
+        return true;
+    }
+    bool MemoryWriteExclusive64(u64 vaddr, std::uint64_t value, [[maybe_unused]] std::uint64_t expected) override {
+        MemoryWrite64(vaddr, value);
+        return true;
+    }
+    bool MemoryWriteExclusive128(u64 vaddr, Vector value, [[maybe_unused]] Vector expected) override {
+        MemoryWrite128(vaddr, value);
+        return true;
+    }
+
+    void InterpreterFallback(u64 pc, size_t num_instructions) override {
+        ASSERT_MSG(false, "InterpreterFallback({:016x}, {})", pc, num_instructions);
+    }
+
+    void CallSVC(std::uint32_t swi) override {
+        struct lfi_proc* p = lfi_sys_proc(jit->GetRegister(21));
+        uint64_t result = p->lfi->opts.syshandler(p->ctxp,
+                                                  jit->GetRegister(8),
+                                                  jit->GetRegister(0),
+                                                  jit->GetRegister(1),
+                                                  jit->GetRegister(2),
+                                                  jit->GetRegister(3),
+                                                  jit->GetRegister(4),
+                                                  jit->GetRegister(5));
+        jit->SetRegister(0, result);
+    }
+
+    void ExceptionRaised(u64 pc, Dynarmic::A64::Exception) override {
+        ASSERT_MSG(false, "ExceptionRaised({:016x})", pc);
+    }
+
+    void AddTicks(std::uint64_t ticks) override {
+        if (ticks > ticks_left) {
+            ticks_left = 0;
+            return;
+        }
+        ticks_left -= ticks;
+    }
+    std::uint64_t GetTicksRemaining() override {
+        return ticks_left;
+    }
+    std::uint64_t GetCNTPCT() override {
+        return 0x10000000000 - ticks_left;
+    }
+};
+
+
+int lfi_proc_entry_dynarmic(struct lfi_proc* proc) {
+    constexpr size_t address_width = 24;
+
+    char* backing_memory = 0;
+    A64FastmemTestEnv env{backing_memory};
+
+    Dynarmic::A64::UserConfig config{&env};
+    config.fastmem_pointer = reinterpret_cast<uintptr_t>(backing_memory);
+    config.fastmem_address_space_bits = address_width;
+    config.recompile_on_fastmem_failure = false;
+    config.silently_mirror_fastmem = true;
+    config.processor_id = 0;
+    config.enable_cycle_counting = false;
+
+    Dynarmic::A64::Jit jit{config};
+    env.jit = &jit;
+
+    std::array<std::uint64_t, 31> regs{proc->regs.x0,
+                                       proc->regs.x1,
+                                       proc->regs.x2,
+                                       proc->regs.x3,
+                                       proc->regs.x4,
+                                       proc->regs.x5,
+                                       proc->regs.x6,
+                                       proc->regs.x7,
+                                       proc->regs.x8,
+                                       proc->regs.x8,
+                                       proc->regs.x10,
+                                       proc->regs.x11,
+                                       proc->regs.x12,
+                                       proc->regs.x13,
+                                       proc->regs.x14,
+                                       proc->regs.x15,
+                                       proc->regs.x16,
+                                       proc->regs.x17,
+                                       proc->regs.x18,
+                                       proc->regs.x19,
+                                       proc->regs.x20,
+                                       proc->regs.x21,
+                                       proc->regs.x22,
+                                       proc->regs.x23,
+                                       proc->regs.x24,
+                                       proc->regs.x25,
+                                       proc->regs.x26,
+                                       proc->regs.x27,
+                                       proc->regs.x28,
+                                       proc->regs.x29,
+                                       proc->regs.x30};
+    jit.SetRegisters(regs);
+    jit.SetPC(proc->regs.x30);
+    jit.SetSP(proc->regs.sp);
+    jit.SetFpsr(0x3480000);
+    jit.SetPstate(0x30000000);
+
+    jit.Run();
+
+    return 0;
+}
+

--- a/liblfi/dynarmic.h
+++ b/liblfi/dynarmic.h
@@ -1,0 +1,17 @@
+#ifndef DYNARMIC_H
+#define DYNARMIC_H
+
+#include "lfi_internal.h" // struct lfi_proc
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+int lfi_proc_entry_dynarmic(struct lfi_proc* proc);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // DYNARMIC_H
+

--- a/liblfi/lfi.h
+++ b/liblfi/lfi.h
@@ -57,6 +57,10 @@ struct lfi_proc_info {
     uint16_t elfphentsize;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Create a new LFI engine with the following options. Returns the new object
 // or NULL if there was an error allocating.
 struct lfi* lfi_new(struct lfi_options options);
@@ -122,6 +126,10 @@ uint64_t lfi_signal_start(uint64_t syspage);
 void lfi_signal_end(uint64_t saved);
 
 struct lfi_proc* lfi_sys_proc(uint64_t syspage);
+
+#ifdef __cplusplus
+}
+#endif
 
 struct lfi_regs {
     uint64_t x0;


### PR DESCRIPTION
Tested with `./run.elf hello.elf` in `example/`.

One caveat is that `lfi_proc_exit()` still isn't handled and will segfault.